### PR TITLE
Adding an InfusionsoftOAuth subclass

### DIFF
--- a/InfusionsoftLibrary.py
+++ b/InfusionsoftLibrary.py
@@ -18,3 +18,10 @@ class Infusionsoft:
 
     def server(self):
         return self.client
+
+class InfusionsoftOAuth(Infusionsoft):
+
+    def __init__(self, access_token):
+        self.client = ServerProxy("https://api.infusionsoft.com/crm/xmlrpc/v1?access_token=%s" % access_token)
+        self.client.error = Error
+        self.key = access_token

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ You can accomplish the same thing using the server library method to access the 
 
 	infusionsoft.server().service.method(infusionsoft.key, args)
 
+#### OAuth Usage
+
+If you are using OAuth, you can instantiate the library using the InfusionsoftOAuth class. The only 
+usage difference is that initialization only requires 1 argument (the OAuth access_token).
+
+```python
+from infusionsoft.library import InfusionsoftOAuth
+
+infusionsoft = InfusionsoftOAuth(access_token)
+```
+
+For more information on OAuth, see the Infusionsoft docs:
+
+https://developer.infusionsoft.com/docs/read/Getting_Started_With_OAuth2
+
 ## Examples
 
 ### Example 1: Add a Contact


### PR DESCRIPTION
Adding OAuth support via a different URL format and class.

Usage is identical to the "api key" version except for instantiation
which is done like so:

``` python
from infusionsoft.library import InfusionsoftOAuth

infusionsoft = InfusionsoftOAuth('oauth access token')
```
