### PR TITLE
Updates to Python library

### DIFF
--- a/infusionsoft/__init__.py
+++ b/infusionsoft/__init__.py
@@ -1,0 +1,3 @@
+from .library import Infusionsoft, InfusionsoftOAuth
+
+__ALL__ = (Infusionsoft, InfusionsoftOAuth)

--- a/infusionsoft/library.py
+++ b/infusionsoft/library.py
@@ -1,9 +1,12 @@
 from xmlrpclib import ServerProxy, Error
 
-class Infusionsoft:
 
-    def __init__(self, name, api_key):
-        self.client = ServerProxy("https://" + name + ".infusionsoft.com/api/xmlrpc")
+class Infusionsoft(object):
+    base_uri = 'https://%s.infusionsoft.com/api/xmlrpc'
+
+    def __init__(self, name, api_key, use_datetime=False):
+        uri = self.base_uri % name
+        self.client = ServerProxy(uri, use_datetime=use_datetime)
         self.client.error = Error
         self.key = api_key
 
@@ -19,9 +22,13 @@ class Infusionsoft:
     def server(self):
         return self.client
 
-class InfusionsoftOAuth(Infusionsoft):
 
-    def __init__(self, access_token):
-        self.client = ServerProxy("https://api.infusionsoft.com/crm/xmlrpc/v1?access_token=%s" % access_token)
+class InfusionsoftOAuth(Infusionsoft):
+    base_uri = 'https://api.infusionsoft.com/crm/xmlrpc/v1?'
+
+    def __init__(self, access_token, use_datetime=False):
+        uri = '%saccess_token=%s' % (self.base_uri, access_token)
+
+        self.client = ServerProxy(uri, use_datetime=use_datetime)
         self.client.error = Error
         self.key = access_token

--- a/setup.py
+++ b/setup.py
@@ -3,26 +3,19 @@
 from distutils.core import setup
 from setuptools import find_packages
 
-dependencies = [
+dependencies = []
+links = []
 
-]
-
-links = [
-    
-]
-
-setup(name='InfusionSoft API',
-      version='0.1',
-      description='python wrapper for InfusionSoft API',
-      author='',
-      author_email='',
-      scripts=[],
-      url='https://github.com/infusionsoft/Official-API-Python-Library',
-      packages=find_packages(),
-      include_package_data=True,
-      install_requires=dependencies,
-      dependency_links = links,
-     )
-
-
-
+setup(
+    name='py-infusionsoft',
+    version='0.2',
+    description='python wrapper for InfusionSoft API',
+    author='',
+    author_email='',
+    scripts=[],
+    url='https://github.com/infusionsoft/Official-API-Python-Library',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=dependencies,
+    dependency_links=links,
+)


### PR DESCRIPTION
I've made a few changes to the library, the most important of which being that it's now possible to set `use_datetime=True` when instantiating an `xmlrpclib.ServerProxy` object so that date objects are returned as `datetime.datetime` objects instead of `xmlrpclib.DateTime` objects. This makes it much, much easier integrate Infusionsoft data with other Python projects, but is option to avoid creating a backwards incompatibility.

In addition, I'm now importing the Infusionsoft and InfusionsoftOAuth classes in the __init__.py file so that they can be imported directly from the module (`from infusionsoft import Infusionsoft` instead of `from infusionsoft.library import Infusionsoft`).

I also, to be more consistent with community practices, and avoid problems with package repositories (I use GemFury to host private packages and this caused issues there due to the space in the name) changed the package name in setup.py from `InfusionSoft API` to `py-infusionsoft`.